### PR TITLE
Merge upstream changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Created by .ignore support plugin (hsz.mobi)
 nvidia-xrun.iml
 .idea
+test-install.sh
+test-cleanup.sh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently sudo is required as the script needs to wake up GPU, modprobe the nvid
 * **/etc/X11/xinit/nvidia-xinitrc** - xinitrc config file. Contains the setting of provider output source
 * **/etc/X11/xinit/nvidia-xinitrc.d** - custom xinitrc scripts directory
 * **/etc/X11/nvidia-xorg.conf.d** - custom X config directory
+* **/etc/default/nvidia-xorg** - nvidia-xrun config file
 * **/usr/share/xsessions/nvidia-xrun-openbox.desktop** - xsession file for openbox
 * **/usr/share/xsessions/nvidia-xrun-plasma.desktop** - xsession file for plasma
 * **[OPTIONAL] ~/.nvidia-xinitrc** - user-level custom xinit script file. You can put here your favourite window manager for example
@@ -44,6 +45,7 @@ Also this way you can adjust some nvidia settings if you encounter issues:
         #  Option "AllowEmptyInitialConfiguration" "Yes"
         #  Option "UseDisplayDevice" "none"
     EndSection
+You also need to set the bus id in the `/etc/default/nvidia-xorg` file - e.g. `BUS_ID=0000:00:01.0`
     
 ## Automatically run window manager
 For convenience you can create `nano ~/.nvidia-xinitrc` and put there your favourite window manager:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When the nvidia-xrun command is used, the device is added again to the tree so t
 * **/etc/X11/xinit/nvidia-xinitrc.d** - custom xinitrc scripts directory
 * **/etc/X11/nvidia-xorg.conf.d** - custom X config directory
 * **/etc/systemd/system/nvidia-xrun-pm.service** systemd service
-* **/etc/default/nvidia-xorg** - nvidia-xrun config file
+* **/etc/default/nvidia-xrun** - nvidia-xrun config file
 * **/usr/share/xsessions/nvidia-xrun-openbox.desktop** - xsession file for openbox
 * **/usr/share/xsessions/nvidia-xrun-plasma.desktop** - xsession file for plasma
 * **[OPTIONAL] ~/.nvidia-xinitrc** - user-level custom xinit script file. You can put here your favourite window manager for example
@@ -60,7 +60,7 @@ Also this way you can adjust some nvidia settings if you encounter issues:
         #  Option "UseDisplayDevice" "none"
     EndSection
 
-You also need to set the bus id in the `/etc/default/nvidia-xorg` file - e.g. `BUS_ID=0000:00:01.0`
+You also need to set the bus id in the `/etc/default/nvidia-xrun` file - e.g. `DEVICE_BUS_ID=0000:00:01.0`
     
 ## Automatically run window manager
 For convenience you can create `nano ~/.nvidia-xinitrc` and put there your favourite window manager:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ Also this way you can adjust some nvidia settings if you encounter issues:
         #  Option "UseDisplayDevice" "none"
     EndSection
 
-You also need to set the bus id in the `/etc/default/nvidia-xrun` file - e.g. `DEVICE_BUS_ID=0000:00:01.0`
-    
+In order to make power management features work properly, you need to make sure
+that bus ids in `/etc/default/nvidia-xrun` are correctly set for both the
+NVIDIA graphic card and the PCI express controller that hosts it. You should be
+able to find both the ids in the output of `lshw`: the PCIe controller is
+usually displayed right before the graphic card.
+
 ## Automatically run window manager
 For convenience you can create `nano ~/.nvidia-xinitrc` and put there your favourite window manager:
 

--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -1,0 +1,5 @@
+BUS_ID=0000:00:01.0
+MODULE_NVIDIA_DRM_PARAMS="modeset=1"
+BUS_RESCAN_WAIT_SEC=1
+MODULES_LOAD=(nvidia nvidia_uvm nvidia_modeset "nvidia_drm modeset=1")
+MODULES_UNLOAD=(nvidia_drm nvidia_modeset nvidia_uvm nvidia)

--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -1,6 +1,5 @@
 CONTROLLER_BUS_ID=0000:00:01.0
 DEVICE_BUS_ID=0000:01:00.0
-MODULE_NVIDIA_DRM_PARAMS="modeset=1"
 BUS_RESCAN_WAIT_SEC=1
 MODULES_LOAD=(nvidia nvidia_uvm nvidia_modeset "nvidia_drm modeset=1")
 MODULES_UNLOAD=(nvidia_drm nvidia_modeset nvidia_uvm nvidia)

--- a/nvidia-xinitrc
+++ b/nvidia-xinitrc
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 userresources=$HOME/.Xresources
 usermodmap=$HOME/.Xmodmap
 sysresources=/etc/X11/xinit/.Xresources
@@ -6,28 +7,28 @@ sysmodmap=/etc/X11/xinit/.Xmodmap
 userxinitrc=$HOME/.nvidia-xinitrc
 
 # merge in defaults and keymaps
-if [ -f ${sysresources} ]; then
+if [[ -f ${sysresources} ]]; then
     xrdb -merge ${sysresources}
 fi
 
-if [ -f ${sysmodmap} ]; then
+if [[ -f ${sysmodmap} ]]; then
     xmodmap ${sysmodmap}
 fi
 
-if [ -f "$userresources" ]; then
+if [[ -f "$userresources" ]]; then
     xrdb -merge "$userresources"
 fi
 
-if [ -f "$usermodmap" ]; then
+if [[ -f "$usermodmap" ]]; then
     xmodmap "$usermodmap"
 fi
 
 export LD_LIBRARY_PATH=/usr/lib64/nvidia/:/usr/lib32/nvidia:/usr/lib:${LD_LIBRARY_PATH}
 
 # load additional configs
-if [ -d /etc/X11/xinit/nvidia-xinitrc.d ] ; then
+if [[ -d /etc/X11/xinit/nvidia-xinitrc.d ]] ; then
  for f in /etc/X11/xinit/nvidia-xinitrc.d/?*.sh ; do
-  [ -x "$f" ] && . "$f"
+  [[ -x "$f" ]] && . "$f"
  done
  unset f
 fi
@@ -35,10 +36,10 @@ fi
 xrandr --setprovideroutputsource modesetting NVIDIA-0
 xrandr --auto
 
-if [ -f "$userxinitrc" ]; then
+if [[ -f "$userxinitrc" ]]; then
     sh ${userxinitrc} $*
 else
-    if [ $# -gt 0 ]; then
+    if [[ $# -gt 0 ]]; then
         sh -c "exec $*"
 	fi
 fi

--- a/nvidia-xinitrc
+++ b/nvidia-xinitrc
@@ -39,6 +39,6 @@ if [ -f "$userxinitrc" ]; then
     sh ${userxinitrc} $#
 else
     if [ $# -gt 0 ]; then
-        "$*"
+        sh -c "exec $*"
 	fi
 fi

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -108,10 +108,8 @@ do
 done
 
 # --------- TURNING OFF GPU ----------
-if [[ -f /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove ]]; then
-  	echo 'Removing Nvidia bus from the kernel'
- 	execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
-else
-	echo 'Enabling powersave for the PCIe controller'
-	execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"
-fi
+echo 'Removing Nvidia bus from the kernel'
+execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
+
+echo 'Enabling powersave for the PCIe controller'
+execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -18,11 +18,13 @@ function execute {
   fi
 }
 
+function turn_off_gpu {
+  echo 'Removing Nvidia bus from the kernel'
+  execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
 
-if [[ $EUID -eq 0 ]]; then
-   echo "This script must not be run as root" >&2
-   exit 1
-fi
+  echo 'Enabling powersave for the PCIe controller'
+  execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"
+}
 
 if [[ "$1" == "-d" ]]
   then
@@ -32,6 +34,16 @@ fi
 
 # load config file
 . /etc/default/nvidia-xrun
+
+# this is used by the systemd service to turn off the gpu at boot
+if [[ "$TURN_OFF_GPU_ONLY" == '1' ]]; then
+  turn_off_gpu && exit 0
+fi
+
+if [[ $EUID -eq 0 ]]; then
+   echo "This script must not be run as root unless TURN_OFF_GPU_ONLY=1 is set" >&2
+   exit 1
+fi
 
 # calculate current VT
 LVT=`fgconsole`
@@ -108,8 +120,4 @@ do
 done
 
 # --------- TURNING OFF GPU ----------
-echo 'Removing Nvidia bus from the kernel'
-execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
-
-echo 'Enabling powersave for the PCIe controller'
-execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"
+turn_off_gpu

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 DRY_RUN=0
 function printHelp {
   echo "Utility to run games and applications in separate X on discrete Nvidia graphic card"
@@ -9,7 +10,7 @@ function printHelp {
 }
 
 function execute {
-  if [ ${DRY_RUN} -eq 1 ]
+  if [[ ${DRY_RUN} -eq 1 ]]
     then
     echo ">>Dry run. Command: $*"
   else
@@ -23,11 +24,14 @@ if [[ $EUID -eq 0 ]]; then
    exit 1
 fi
 
-if [ "$1" == "-d" ]
+if [[ "$1" == "-d" ]]
   then
     DRY_RUN=1
     shift 1
 fi
+
+# load config file
+. /etc/default/nvidia-xrun
 
 # calculate current VT
 LVT=`fgconsole`
@@ -35,7 +39,7 @@ LVT=`fgconsole`
 # calculate first usable display
 XNUM="-1"
 SOCK="something"
-while [ ! -z "$SOCK" ] 
+while [[ ! -z "$SOCK" ]]
 do
   XNUM=$(( $XNUM + 1 ))
   SOCK=$(ls -A -1 /tmp/.X11-unix | grep "X$XNUM" )
@@ -43,15 +47,15 @@ done
 
 NEWDISP=":$XNUM"
 
-if [ ! -z "$*" ] # generate exec line if arguments are given
-then 
+if [[ ! -z "$*" ]] # generate exec line if arguments are given
+then
   # test if executable exists in path
-  if [ -x "$(which $1 2> /dev/null)" ]
+  if [[ -x "$(which $1 2> /dev/null)" ]]
   then
     # generate exec line
     EXECL="$(which $1)"
   # test if executable exists on disk
-  elif [ -e "$(realpath "$1")" ]
+  elif [[ -e "$(realpath "$1")" ]]
   then
     # generate exec line
     EXECL="$(realpath "$1")"
@@ -70,50 +74,38 @@ EXECL="/etc/X11/xinit/nvidia-xinitrc \"$EXECL\""
 COMMAND="xinit $EXECL -- $NEWDISP vt$LVT -nolisten tcp -br -config nvidia-xorg.conf -configdir nvidia-xorg.conf.d"
 
 # --------- TURNING ON GPU -----------
-echo 'Waking up nvidia GPU'
-if ! [ -f /proc/acpi/bbswitch ] 
-then
-  execute "sudo modprobe bbswitch"
+if [[ ! -d /sys/bus/pci/devices/${BUS_ID} ]]; then
+	echo 'Rescanning PCI devices'
+	execute "sudo tee /sys/bus/pci/rescan <<<1"
+	echo "Waiting ${BUS_RESCAN_WAIT_SEC} second for rescan"
+	execute "sleep ${BUS_RESCAN_WAIT_SEC}"
 fi
-execute "sudo tee /proc/acpi/bbswitch <<<ON"
+
+echo 'Turning the card on'
+execute "sudo tee /sys/bus/pci/devices/${BUS_ID}/power/control <<<on"
 
 # ---------- LOADING MODULES ----------
-echo 'Loading nvidia module'
-execute "sudo modprobe nvidia"
-
-echo 'Loading nvidia_uvm module'
-execute "sudo modprobe nvidia_uvm"
-
-echo 'Loading nvidia_modeset module'
-execute "sudo modprobe nvidia_modeset"
-
-echo 'Loading nvidia_drm module'
-execute "sudo modprobe nvidia_drm modeset=1"
+for module in "${MODULES_LOAD[@]}"
+do
+   	echo "Loading module ${module}"
+	execute "sudo modprobe ${module}"
+done
 
 # ---------- EXECUTING COMMAND --------
 execute ${COMMAND}
 
 # ---------- UNLOADING MODULES --------
-echo 'Unloading nvidia_drm module'
-execute "sudo rmmod nvidia_drm"
-
-echo 'Unloading nvidia_modeset module'
-execute "sudo rmmod nvidia_modeset"
-
-echo 'Unloading nvidia_uvm module'
-execute "sudo rmmod nvidia_uvm"
-
-echo 'Unloading nvidia module'
-execute "sudo rmmod nvidia"
+for module in "${MODULES_UNLOAD[@]}"
+do
+   	echo "Unloading module ${module}"
+	execute "sudo modprobe ${module}"
+done
 
 # --------- TURNING OFF GPU ----------
-if [ -f /proc/acpi/bbswitch ] 
-then
-  echo 'Turning off nvidia GPU'
-  execute "sudo tee /proc/acpi/bbswitch <<<OFF"
-
-  echo -n 'Current state of nvidia GPU: '
-  execute "cat /proc/acpi/bbswitch"
+if [[ -f /sys/bus/pci/devices/${BUS_ID}/remove ]]; then
+  	echo 'Removing Nvidia bus from the kernel'
+ 	execute "sudo tee /sys/bus/pci/devices/${BUS_ID}/remove <<<1"
 else
-  echo "Bbswitch kernel module not loaded."
+	echo 'Enabling powersave for the PCIe controller'
+	execute "sudo tee /sys/bus/pci/devices/${BUS_ID}/power/control <<<auto"
 fi

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -65,7 +65,7 @@ else # prepare to start new X sessions if no arguments passed
   EXECL=""
 fi
 
-EXECL="/etc/X11/xinit/nvidia-xinitrc $EXECL"
+EXECL="/etc/X11/xinit/nvidia-xinitrc \"$EXECL\""
 
 COMMAND="xinit $EXECL -- $NEWDISP vt$LVT -nolisten tcp -br -config nvidia-xorg.conf -configdir nvidia-xorg.conf.d"
 
@@ -85,7 +85,7 @@ echo 'Loading nvidia_modeset module'
 execute "sudo modprobe nvidia_modeset"
 
 echo 'Loading nvidia_drm module'
-execute "sudo modprobe nvidia_drm"
+execute "sudo modprobe nvidia_drm modeset=1"
 
 # ---------- EXECUTING COMMAND --------
 execute ${COMMAND}

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -104,7 +104,7 @@ execute ${COMMAND}
 for module in "${MODULES_UNLOAD[@]}"
 do
    	echo "Unloading module ${module}"
-	execute "sudo modprobe ${module}"
+	execute "sudo modprobe -r ${module}"
 done
 
 # --------- TURNING OFF GPU ----------

--- a/nvidia-xrun-pm.service
+++ b/nvidia-xrun-pm.service
@@ -3,8 +3,8 @@ Description="Remove Nvidia GPU from kernel devices list and enable PM"
 
 [Service]
 Type=oneshot
-ExecStartPre=/bin/bash -c 'echo 1 > /sys/bus/pci/devices/0000:01:00.0/remove'
-ExecStart=/bin/bash -c 'echo auto > /sys/bus/pci/devices/0000:00:01.0/power/control'
+Environment="TURN_OFF_GPU_ONLY=1"
+ExecStart=/usr/bin/nvidia-xrun
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR:

- integrates upstream changes
- fixes some bugs (for example `modprobe` instead of `modprobe -r` and wrong logic)
- integrates the systemd service with the main script (to keep it DRY)
- introduces a `TURN_OFF_GPU_ONLY=1` envvar to only turn off the GPU without executing commands (used by the systemd service)

@samuelstjean can you please test this? It works for me. You need to set both `DEVICE_BUS_ID` and `CONTROLLER_BUS_ID` in `/etc/default/nvidia-xrun`.