### PR TITLE
Update RPM to use GitHub source

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ With this you do not need to specify the app and you can simply run:
 
     nvidia-xrun
 
-## Aur package
-The aur package can be found here: https://aur.archlinux.org/packages/nvidia-xrun/
+## AUR package
+The AUR package can be found here: https://aur.archlinux.org/packages/nvidia-xrun-pm/
 
-## COPR Repo for Fedora 27+
-### To Install from COPR
-* `dnf copr enable axeld/nvidia-xrun`
-* `dnf install nvidia-xrun`
+## COPR Repository for Fedora, RHEL, and openSUSE
+The repository details and RPM packages for all supported distributions can be found on the [ekultails/nvidia-xrun-pm](https://copr.fedorainfracloud.org/coprs/ekultails/nvidia-xrun-pm/) overview page.
 
-## OBS Repo for OpenSUSE, Fedora 27+ and RHEL7
-The OBS Repo can be found [here](https://software.opensuse.org//download.html?project=home%3AAxelSilverdew&package=nvidia-xrun)
+### Install (Fedora and RHEL)
+* `dnf copr enable ekultails/nvidia-xrun-pm`
+* `dnf install nvidia-xrun-pm`
+
 
 
 ## Troubleshooting

--- a/rpm-spec/nvidia-xrun.spec
+++ b/rpm-spec/nvidia-xrun.spec
@@ -1,34 +1,37 @@
-%define nvidia_xrun_pm_version 0.3.2
+%define version 0.3.2
 Name: nvidia-xrun-pm
-Version: %{nvidia_xrun_pm_version}
-Release: 1%{?dist}
+Version: %{version}
+Release: 2%{?dist}
 Summary: Utility to run separate X with discrete nvidia graphics with full performance.
 License: GNU GPLv2
 buildroot: %{_tmppath}/%{name}-root
 BuildArch: noarch
 Conflicts: nvidia-xrun
-# The "systemd" package is required for the %{_unitdir} macro.
-BuildRequires: git systemd
+# This forces the remote source code to be downloaded during the rpmbuild.
+# It is ignored on Fedora COPR. A source RPM must be built elsewhere
+# before being uploaded to be built as a binary RPM.
+%undefine _disable_source_fetch
+Source0: https://github.com/michelesr/nvidia-xrun-pm/archive/%{version}.tar.gz
+# The "systemd" package is required for the "_unitdir" macro.
+BuildRequires: systemd
 
 %description
 This fork provides the benefits of nvidia-xrun without the extra dependency of bumblebee for power management. These utility scripts aim to make the life easier for nvidia cards users. It started with a revelation that bumblebee in current state offers very poor performance. This solution offers a bit more complicated procedure but offers a full GPU utilization.
 
-%build
-rm -rf nvidia-xrun-pm
-# SSL verification is turned off to temporarily workaround openSUSE Leap build issues on COPR.
-git -c http.sslVerify=false clone --depth 1 --single-branch --branch %{nvidia_xrun_pm_version}\
- https://github.com/michelesr/nvidia-xrun-pm.git
+%prep
+# Extract the source tarball to ~/rpmbuild/BUILD/.
+%setup -q
 
 %install
 mkdir -p %{buildroot}/%{_bindir}
-install -pm 755 nvidia-xrun-pm/nvidia-xrun %{buildroot}/%{_bindir}
+install -pm 755 %{_builddir}/nvidia-xrun-pm-%{version}/nvidia-xrun %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_sysconfdir}/X11/xinit/
-install -pm 644 nvidia-xrun-pm/nvidia-xorg.conf %{buildroot}/%{_sysconfdir}/X11/
-install -pm 755 nvidia-xrun-pm/nvidia-xinitrc %{buildroot}/%{_sysconfdir}/X11/xinit/
+install -pm 644 %{_builddir}/nvidia-xrun-pm-%{version}/nvidia-xorg.conf %{buildroot}/%{_sysconfdir}/X11/
+install -pm 755 %{_builddir}/nvidia-xrun-pm-%{version}/nvidia-xinitrc %{buildroot}/%{_sysconfdir}/X11/xinit/
 mkdir -p %{buildroot}/%{_sysconfdir}/default
-install -pm 644 nvidia-xrun-pm/config/nvidia-xrun %{buildroot}/%{_sysconfdir}/default/
+install -pm 644 %{_builddir}/nvidia-xrun-pm-%{version}/config/nvidia-xrun %{buildroot}/%{_sysconfdir}/default/
 mkdir -p %{buildroot}/%{_unitdir}/
-install -pm 644 nvidia-xrun-pm/nvidia-xrun-pm.service %{buildroot}/%{_unitdir}/
+install -pm 644 %{_builddir}/nvidia-xrun-pm-%{version}/nvidia-xrun-pm.service %{buildroot}/%{_unitdir}/
 
 %files
 %{_bindir}/nvidia-xrun
@@ -39,6 +42,9 @@ install -pm 644 nvidia-xrun-pm/nvidia-xrun-pm.service %{buildroot}/%{_unitdir}/
 %{_unitdir}/nvidia-xrun-pm.service
 
 %changelog
+* Thu Apr 25 2019 Luke Short <ekultails@gmail.com> 0.3.2-2
+- Use GitHub release tarballs instead of a git clone
+
 * Wed Apr 24 2019 Luke Short <ekultails@gmail.com> 0.3.2-1
 - Use the git version tag for the RPM
 - Add the new default nvidia-xrun configuration file

--- a/rpm-spec/nvidia-xrun.spec
+++ b/rpm-spec/nvidia-xrun.spec
@@ -1,36 +1,48 @@
+%define nvidia_xrun_pm_version 0.3.2
 Name: nvidia-xrun-pm
-Version: 20181128
+Version: %{nvidia_xrun_pm_version}
 Release: 1%{?dist}
 Summary: Utility to run separate X with discrete nvidia graphics with full performance.
 License: GNU GPLv2
-Source0: nvidia-xrun
-Source1: nvidia-xorg.conf
-Source2: nvidia-xinitrc
-Source3: nvidia-xrun-pm.service
 buildroot: %{_tmppath}/%{name}-root
 BuildArch: noarch
 Conflicts: nvidia-xrun
+# The "systemd" package is required for the %{_unitdir} macro.
+BuildRequires: git systemd
 
 %description
 This fork provides the benefits of nvidia-xrun without the extra dependency of bumblebee for power management. These utility scripts aim to make the life easier for nvidia cards users. It started with a revelation that bumblebee in current state offers very poor performance. This solution offers a bit more complicated procedure but offers a full GPU utilization.
 
+%build
+rm -rf nvidia-xrun-pm
+# SSL verification is turned off to temporarily workaround openSUSE Leap build issues on COPR.
+git -c http.sslVerify=false clone --depth 1 --single-branch --branch %{nvidia_xrun_pm_version}\
+ https://github.com/michelesr/nvidia-xrun-pm.git
+
 %install
 mkdir -p %{buildroot}/%{_bindir}
-install -pm 755 %{SOURCE0} %{buildroot}/%{_bindir}
+install -pm 755 nvidia-xrun-pm/nvidia-xrun %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_sysconfdir}/X11/xinit/
-install -pm 644 %{SOURCE1} %{buildroot}/%{_sysconfdir}/X11/
-install -pm 755 %{SOURCE2} %{buildroot}/%{_sysconfdir}/X11/xinit/
+install -pm 644 nvidia-xrun-pm/nvidia-xorg.conf %{buildroot}/%{_sysconfdir}/X11/
+install -pm 755 nvidia-xrun-pm/nvidia-xinitrc %{buildroot}/%{_sysconfdir}/X11/xinit/
+mkdir -p %{buildroot}/%{_sysconfdir}/default
+install -pm 644 nvidia-xrun-pm/config/nvidia-xrun %{buildroot}/%{_sysconfdir}/default/
 mkdir -p %{buildroot}/%{_unitdir}/
-install -pm 644 %{SOURCE3} %{buildroot}/%{_unitdir}/
+install -pm 644 nvidia-xrun-pm/nvidia-xrun-pm.service %{buildroot}/%{_unitdir}/
 
 %files
 %{_bindir}/nvidia-xrun
 %{_sysconfdir}/X11/nvidia-xorg.conf
 %{_sysconfdir}/X11/xinit
 %{_sysconfdir}/X11/xinit/nvidia-xinitrc
+%{_sysconfdir}/default/nvidia-xrun
 %{_unitdir}/nvidia-xrun-pm.service
 
 %changelog
+* Wed Apr 24 2019 Luke Short <ekultails@gmail.com> 0.3.2-1
+- Use the git version tag for the RPM
+- Add the new default nvidia-xrun configuration file
+
 * Thu Jan 31 2019 Luke Short <ekultails@gmail.com> 20181128-1
 - Change to ISO date version format
 - Mark nvidia-xrun as a conflicting package


### PR DESCRIPTION
This allows us to pin the RPM package version to a git tag. I have also updated the documentation on where to find built packages for Arch Linux and RPM-based distros. I have builds for `nvidia-xrun-pm` on Fedora, RHEL, and openSUSE on COPR now.

The oiginal conversation about these changes can be found in this GitHub issue: https://github.com/michelesr/nvidia-xrun-pm/issues/3